### PR TITLE
fix: add readme in the crates.io page trough Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ license = "Apache-2.0"
 name = "yamusic"
 repository = "https://github.com/yamusic/yamusic"
 version = "0.0.1"
+readme = "README.md"
 
 [dependencies]
 # Core 


### PR DESCRIPTION
This pull request closes #33, adding the entry for `readme` in the `Cargo.toml` file.